### PR TITLE
Drop py3.5, add py3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,27 +39,27 @@ jobs:
   doctest:
     <<: *common
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.6
         environment:
           TOXENV: doctest
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.5
+      - image: circleci/python:3.6
         environment:
           TOXENV: lint
-  py35-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-core
   py36-core:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-core
+  py37-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-core
   pypy3-core:
     <<: *common
     docker:
@@ -72,6 +72,6 @@ workflows:
     jobs:
       - doctest
       - lint
-      - py35-core
       - py36-core
+      - py37-core
       - pypy3-core

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,23 +4,23 @@ dist: trusty
 matrix:
   include:
     #
-    # Python 3.5 testing
-    #
-    # lint
-    - python: "3.5"
-      env: TOX_POSARGS="-e lint"
-    # doctest
-    - python: "3.5"
-      env: TOX_POSARGS="-e doctest"
-    # core
-    - python: "3.5"
-      env: TOX_POSARGS="-e py35-core"
-    #
     # Python 3.6 testing
     #
     # core
     - python: "3.6"
       env: TOX_POSARGS="-e py36-core"
+    # lint
+    - python: "3.6"
+      env: TOX_POSARGS="-e lint"
+    # doctest
+    - python: "3.6"
+      env: TOX_POSARGS="-e doctest"
+    #
+    # Python 3.7 testing
+    #
+    # core
+    - python: "3.7"
+      env: TOX_POSARGS="-e py37-core"
     #
     # pypy3 testing
     #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -273,7 +273,7 @@ texinfo_documents = [
 # -- Intersphinx configuration ------------------------------------------------
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.5', None),
+    'python': ('https://docs.python.org/3.6', None),
 }
 
 # -- Doctest configuration ----------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "eth-utils>=1,<2",
     ],
     setup_requires=['setuptools-markdown'],
-    python_requires='>=3.5, <4',
+    python_requires='>=3.6, <4',
     extras_require=extras_require,
     py_modules=['<MODULE_NAME>'],
     license="MIT",
@@ -62,8 +62,8 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36,py3}-core
+    py{36,37,py3}-core
     lint
     doctest
 
@@ -26,8 +26,8 @@ commands=
     doctest: make -C {toxinidir}/docs doctest
 basepython =
     doctest: python
-    py35: python3.5
     py36: python3.6
+    py37: python3.7
     pypy3: pypy3
 extras=
     test


### PR DESCRIPTION
## What was wrong?

Any new projects should be defaulting to python 3.6+, and including support for py3.7. The template was still on 3.5.

## How was it fixed?

Dropped py3.5 from the pypi classifications, circle, tox, travis, and docs setups.
Added py3.7 to all those. (except docs, which moves to py3.6)

(oops I pushed a branch to upstream, just fixed locally. won't do it again)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i2.pickpik.com/photos/250/470/388/meerkat-zoo-animal-sand-preview.jpg)

*seven meerkats, I promise*