### PR TITLE
Add docstring checking with pydocstyle

### DIFF
--- a/.pydocstyle.ini
+++ b/.pydocstyle.ini
@@ -1,0 +1,30 @@
+[pydocstyle]
+; All error codes found here:
+; http://www.pydocstyle.org/en/3.0.0/error_codes.html
+;
+; Ignored:
+; D1 - Missing docstring error codes
+;
+; Selected:
+; D2 - Whitespace error codes
+; D3 - Quote error codes
+; D4 - Content related error codes
+select=D2,D3,D4
+
+; Extra ignores:
+; D200 - One-line docstring should fit on one line with quotes
+; D203 - 1 blank line required before class docstring
+; D204 - 1 blank line required after class docstring
+; D205 - 1 blank line required between summary line and description
+; D212 - Multi-line docstring summary should start at the first line
+; D302 - Use u""" for Unicode docstrings
+; D400 - First line should end with a period
+; D401 - First line should be in imperative mood
+; D412 - No blank lines allowed between a section header and its content
+add-ignore=D200,D203,D204,D205,D212,D302,D400,D401,D412
+
+; Explanation:
+; D400 - Enabling this error code seems to make it a requirement that the first
+; sentence in a docstring is not split across two lines.  It also makes it a
+; requirement that no docstring can have a multi-sentence description without a
+; summary line.  Neither one of those requirements seem appropriate.

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ extras_require = {
     'lint': [
         "flake8==3.4.1",
         "isort>=4.2.15,<5",
+        "pydocstyle>=3.0.0,<4",
     ],
     'doc': [
         "Sphinx>=1.6.5,<2",

--- a/tox.ini
+++ b/tox.ini
@@ -40,3 +40,4 @@ extras=lint
 commands=
     flake8 {toxinidir}/<MODULE_NAME> {toxinidir}/tests
     isort --recursive --check-only --diff {toxinidir}/<MODULE_NAME> {toxinidir}/tests
+    pydocstyle {toxinidir}/<MODULE_NAME> {toxinidir}/tests


### PR DESCRIPTION
## What was wrong?

Per the discussion in [this](https://github.com/ethereum/snake-charmers-tactical-manual/pull/36) issue, it seems that including the use of a docstring linting tool in the test suite could be useful.

## How was it fixed?

Added a run of `pydocstyle` to the tox "lint" environment.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://anthonyrenditya.files.wordpress.com/2011/04/jumping-fox.jpg)
