### PR TITLE
switch to native pypy markdown support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,18 +31,24 @@ extras_require = {
 }
 
 extras_require['dev'] = (
-    extras_require['dev'] +
-    extras_require['test'] +
-    extras_require['lint'] +
+    extras_require['dev'] +  # noqa: W504
+    extras_require['test'] +  # noqa: W504
+    extras_require['lint'] +  # noqa: W504
     extras_require['doc']
 )
+
+
+with open('./README.md') as readme:
+    long_description = readme.read()
+
 
 setup(
     name='<PYPI_NAME>',
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
     version='0.1.0-alpha.0',
     description="""<PYPI_NAME>: <SHORT_DESCRIPTION>""",
-    long_description_markdown_filename='README.md',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author='The Ethereum Foundation',
     author_email='snakecharmers@ethereum.org',
     url='https://github.com/ethereum/<REPO_NAME>',
@@ -50,7 +56,6 @@ setup(
     install_requires=[
         "eth-utils>=1,<2",
     ],
-    setup_requires=['setuptools-markdown'],
     python_requires='>=3.6, <4',
     extras_require=extras_require,
     py_modules=['<MODULE_NAME>'],


### PR DESCRIPTION
## What was wrong?

pypi now supports native markdown long descriptions.

## How was it fixed?

Switched to use it.

#### Cute Animal Picture

![Depositphotos_31010265_m-2015-1](https://user-images.githubusercontent.com/824194/57040914-104fe180-6c1e-11e9-8a17-5e6fa3d31fb9.jpg)

