### PR TITLE
Skip venv in template filler & print progress

### DIFF
--- a/.project-template/fill_template_vars.sh
+++ b/.project-template/fill_template_vars.sh
@@ -29,7 +29,8 @@ echo "What is a one-liner describing the project?"
 read SHORT_DESCRIPTION
 
 _replace() {
-  local find_cmd=(find "$PROJECT_ROOT" ! -perm -u=x ! -path '*/.git/*' -type f)
+  echo "Replacing values: $1"
+  local find_cmd=(find "$PROJECT_ROOT" ! -perm -u=x ! -path '*/.git/*' ! -path '*/venv*/*' -type f)
 
   if [[ $(uname) == Darwin ]]; then
     "${find_cmd[@]}" -exec sed -i '' "$1" {} +


### PR DESCRIPTION
## What was wrong?

Tried to replace template variables in `venv/` (this is slow, and wrong)
Couldn't tell progress (or tell if there was an error during one of the replacement attempts).

## How was it fixed?

- exclude `venv*/` folders
- display when attempting to replace values, and which ones are being attempted.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.pinimg.com/originals/ec/8b/6f/ec8b6f4394030765023ae08b035c8b11.jpg)
