### PR TITLE
Define copyright more broadly

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 The Ethereum Foundation
+Copyright (c) 2019 The <PROJECT_NAME> contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = '<PROJECT_NAME>'
-copyright = '2019, The Ethereum Foundation'
+copyright = '2019, The <PROJECT_NAME> contributors'
 
 __version__ = setup_version
 # The version info for the project you're documenting, acts as replacement for
@@ -210,7 +210,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
   ('index', '<MODULE_NAME>.tex', '<PROJECT_NAME> Documentation',
-   'The Ethereum Foundation', 'manual'),
+   'The <PROJECT_NAME> contributors', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -240,7 +240,7 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', '<MODULE_NAME>', '<PROJECT_NAME> Documentation',
-     ['The Ethereum Foundation'], 1)
+     ['The <PROJECT_NAME> contributors'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -254,7 +254,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
   ('index', '<PROJECT_NAME>', '<PROJECT_NAME> Documentation',
-   'The Ethereum Foundation', '<PROJECT_NAME>', '<SHORT_DESCRIPTION>',
+   'The <PROJECT_NAME> contributors', '<PROJECT_NAME>', '<SHORT_DESCRIPTION>',
    'Miscellaneous'),
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     description="""<PYPI_NAME>: <SHORT_DESCRIPTION>""",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    author='The Ethereum Foundation',
+    author='The <PROJECT_NAME> contributors',
     author_email='snakecharmers@ethereum.org',
     url='https://github.com/ethereum/<REPO_NAME>',
     include_package_data=True,


### PR DESCRIPTION
## What was wrong?

The copyright is currently defined as "The Ethereum Foundation". It sounds slightly more inclusive to non EF people to define this as "The <PROJECT_NAME> contributor".

## How was it fixed?

Replaced "The Ethereum Foundation" with "The <PROJECT_NAME> contributor"

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2016/01/cute-squirrel-photography-121__700.jpg)
