### PR TITLE
Replace web3 reference with <MODULE_NAME>

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -85,17 +85,17 @@ qthelp:
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
 	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/web3.qhcp"
+	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/<MODULE_NAME>.qhcp"
 	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/web3.qhc"
+	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/<MODULE_NAME>.qhc"
 
 devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
 	@echo
 	@echo "Build finished."
 	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/web3"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/web3"
+	@echo "# mkdir -p $$HOME/.local/share/devhelp/<MODULE_NAME>"
+	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/<MODULE_NAME>"
 	@echo "# devhelp"
 
 epub:


### PR DESCRIPTION
## What was wrong?

Some hard-coded references to web3.py slipped through. Clearly this user path is not tested very often. In eth-abi, it still said EthereumAlarmClock X)

## How was it fixed?

Replaced web3 reference with <MODULE_NAME>

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/aajrxyjn4pc41.jpg?width=640&crop=smart&auto=webp&s=a4349db70f8b582d805f617db85f8851bf3e6a5d)
