### PR TITLE
Better error if bump missing in make notes/release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,12 @@ docs: build-docs
 linux-docs: build-docs
 	xdg-open docs/_build/html/index.html
 
-notes:
+check-bump:
+ifndef bump
+	$(error bump must be set, typically: major, minor, patch, or devnum)
+endif
+
+notes: check-bump
 	# Let UPCOMING_VERSION be the version that is used for the current bump
 	$(eval UPCOMING_VERSION=$(shell bumpversion $(bump) --dry-run --list | grep new_version= | sed 's/new_version=//g'))
 	# Now generate the release notes to have them included in the release commit
@@ -59,7 +64,7 @@ notes:
 	make build-docs
 	git commit -m "Compile release notes"
 
-release: clean
+release: check-bump clean
 	# require that you be on a branch that's linked to upstream/master
 	git status -s -b | head -1 | grep "\.\.upstream/master"
 	# verify that docs build correctly


### PR DESCRIPTION
## What was wrong?

Forgot to put the `bump` variable in the `make notes` command, and the error message took me a minute to understand. It should be a simple/clear message.

## How was it fixed?

Added an explicit check for the `bump` variable in `make notes` and `make release`

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcQQTK0RaKcfZbZCi2cgTNIQEf-gjUpmMkHJNFST2yTWcECyvNE1&usqp=CAU)
