### PR TITLE
Add IDE filenames to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,9 +97,10 @@ logs
 
 # IntelliJ
 /out/
+.idea*
 
-# mpeltonen/sbt-idea plugin
-.idea_modules/
+#pip wheel metadata
+pip-wheel-metadata
 
 # JIRA plugin
 atlassian-ide-plugin.xml


### PR DESCRIPTION
## What was wrong?
IDE files such as .idea and pip-wheel-metadata were not included in .gitignore

## How was it fixed?
.idea* and pip-wheel-metadata were added to the .gitignore file
