### PR TITLE
Export type annotations to importing projects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     zip_safe=False,
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
+    package_data={'<MODULE_NAME>': ['py.typed']},
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
## What was wrong?

Packages aren't exporting their type annotations by default.

Fixes #30 

## How was it fixed?

Export type annotations by default.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.chzbgr.com/full/4829058304/h6F456D7D/acting-like-animals-dear-tumblr-im-bored)
