### PR TITLE
Fix the type annotations export, adding py.typed

### DIFF
--- a/.project-template/fill_template_vars.sh
+++ b/.project-template/fill_template_vars.sh
@@ -47,3 +47,4 @@ _replace "s/<SHORT_DESCRIPTION>/$SHORT_DESCRIPTION/g"
 
 mkdir -p "$PROJECT_ROOT/$MODULE_NAME"
 touch "$PROJECT_ROOT/$MODULE_NAME/__init__.py"
+touch "$PROJECT_ROOT/$MODULE_NAME/py.typed"


### PR DESCRIPTION
## What was wrong?

Fixes https://github.com/ethereum/ethereum-python-project-template/issues/30

## How was it fixed?

`{MODULE_NAME}/py.typed` was missing; add it.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

[//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://media4.s-nbcnews.com/i/newscms/2020_12/1549674/pet-sanity-coronavirus-today-main-0200318_0d2d919866aa88a02596016bbc578065.jpg)
