### PR TITLE
Update .gitignore based on IntelliJ docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,8 +85,8 @@ logs
 .idea/**/libraries
 
 
-## Uncomment if using auto-import.
-# .idea/*.iml
+#Comment out if not using auto-import.
+.idea/*.iml
 
 ## PyCharm Patch
 # Comment Reason : https://github.com/toptal/gitignore.io/issues/215

--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,7 @@ logs
 
 
 ## Uncomment if using auto-import.
-# .idea/py_ecc.iml
+# .idea/*.iml
 
 ## PyCharm Patch
 # Comment Reason : https://github.com/toptal/gitignore.io/issues/215

--- a/.gitignore
+++ b/.gitignore
@@ -71,9 +71,32 @@ logs
 # For a more precise, explicit template, see:
 # https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-## General
-.idea/*
-.idea_modules/*
+
+## User Specific
+.idea/**/dictionaries
+.idea/**/workspace.xml
+.idea/**/usage.statistics.xml
+.idea/**/tasks.xml
+.idea/**/shelf
+
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+
+## Uncomment if using auto-import.
+# .idea/py_ecc.iml
+
+## PyCharm Patch
+# Comment Reason : https://github.com/toptal/gitignore.io/issues/215
+# .idea/misc.xml
+
+
+## Other IDEA - uncomment if necessaary
+# .idea/inspectionProfiles/Project_Default.xml
+# .idea/inspectionProfiles/profiles_settings.xml
+
 
 ## File-based project format:
 *.iws


### PR DESCRIPTION
updated based on IntelliJ documentation

## What was wrong?
`.idea/*` listed in `.gitignore` encompassed `.idea `files that we want to share rather than ignore.

Related to : https://github.com/ethereum/ethereum-python-project-template/pull/50#issuecomment-784466608

## How was it fixed?
Specific `.idea` files were listed in .gitignore based on IntelliJ documentation [here](https://intellij-support.jetbrains.com/hc/en-us/articles/206544839).

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://piximus.net/media/513/tiny-animals-1.jpg)
