### PR TITLE
Exclude huge and unnecessary venv*/ from dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ global-include *.pyi
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+recursive-exclude * venv*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,4 @@ global-include *.pyi
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
-recursive-exclude * venv*
+prune venv*


### PR DESCRIPTION
See an example issue here:
https://github.com/ethereum/eth-account/issues/150

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.scotsman.com/webimg/b25lY21zOjNhMmE1NmE0LTllYmUtNGE3ZC05YWFmLWQyMDJlODM1MTUyNTo5MWQ4OTU4OS01ODVhLTRjZDEtODk4YS03NjVkNzBjNmY4MzI=.jpg?crop=61:45,smart&width=800)
