### PR TITLE
Use updated CircleCI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,43 +39,43 @@ jobs:
   docs:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: docs
   lint:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: lint
   py36-core:
     <<: *common
     docker:
-      - image: circleci/python:3.6
+      - image: cimg/python:3.6
         environment:
           TOXENV: py36-core
   py37-core:
     <<: *common
     docker:
-      - image: circleci/python:3.7
+      - image: cimg/python:3.7
         environment:
           TOXENV: py37-core
   py38-core:
     <<: *common
     docker:
-      - image: circleci/python:3.8
+      - image: cimg/python:3.8
         environment:
           TOXENV: py38-core
   py39-core:
     <<: *common
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TOXENV: py39-core
   py310-core:
     <<: *common
     docker:
-      - image: circleci/python:3.10
+      - image: cimg/python:3.10
         environment:
           TOXENV: py310-core
   pypy3-core:


### PR DESCRIPTION
See https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

CircleCI is now showing a warning when using the older images. I haven't run into any particular problem, but when debugging other issues, it's always nice to get rid of all the warnings.

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://static.boredpanda.com/blog/wp-content/uploads/2017/04/perfectly-round-animals-62-58eb4243c8e5f__700.jpg)
