### PR TITLE
Upgrade towncrier to fix the duplicate title bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build-docs:
 	$(MAKE) -C docs html
 	$(MAKE) -C docs doctest
 	./newsfragments/validate_files.py
-	towncrier --draft --version preview
+	towncrier build --draft --version preview
 
 docs: build-docs
 	open docs/_build/html/index.html
@@ -63,7 +63,7 @@ notes: check-bump
 	# Let UPCOMING_VERSION be the version that is used for the current bump
 	$(eval UPCOMING_VERSION=$(shell bumpversion $(bump) --dry-run --list | grep new_version= | sed 's/new_version=//g'))
 	# Now generate the release notes to have them included in the release commit
-	towncrier --yes --version $(UPCOMING_VERSION)
+	towncrier build --yes --version $(UPCOMING_VERSION)
 	# Before we bump the version, make sure that the towncrier-generated docs will build
 	make build-docs
 	git commit -m "Compile release notes"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras_require = {
     'doc': [
         "Sphinx>=1.6.5,<2",
         "sphinx_rtd_theme>=0.1.9,<1",
-        "towncrier>=19.2.0, <20",
+        "towncrier>=21,<22",
     ],
     'dev': [
         "bumpversion>=0.5.3,<1",


### PR DESCRIPTION
## What was wrong?

Old Towncrier version prints the titles in duplicate when you set a custom section title.

## How was it fixed?

Upgraded to v21, and added the new build subcommand.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://thumbs.dreamstime.com/z/funny-animal-chipmunk-shouting-megaphone-isolated-white-101472245.jpg)
