### PR TITLE
Add a validate docs command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,12 @@ build-docs:
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(MAKE) -C docs doctest
-	./newsfragments/validate_files.py
-	towncrier build --draft --version preview
 
-docs: build-docs
+validate-docs:
+	python ./newsfragments/validate_files.py
+	towncrier --draft --version preview
+
+docs: build-docs validate-docs
 	open docs/_build/html/index.html
 
 linux-docs: build-docs


### PR DESCRIPTION
## What was wrong?

IMHO, It makes more sense to validate doc files separately from the build docs step.

## How was it fixed?

split out the two commands. 

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

[//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://m.media-amazon.com/images/I/71vpu1-uwaL._AC_SL1100_.jpg)
