### PR TITLE
Don't push .tox file to tar.gz release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,5 @@ global-include *.pyi
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+prune .tox
 prune venv*


### PR DESCRIPTION
It can get big with installed libraries. On a relatively small release
of eth-portal, this one change cut the .tar.gz release size from 574Kb
to 14Kb.
