### PR TITLE
Use updated tox command in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ common: &common
         command: pip install --user tox
     - run:
         name: run tox
-        command: ~/.local/bin/tox -r
+        command: python -m tox -r
     - save_cache:
         paths:
           - .hypothesis


### PR DESCRIPTION
## What was wrong?

Forgot to add this to the last PR - The `~/.local/bin/tox` command eventually fails in CI with the updated images. 

## How was it fixed?

Made the tox command `python -m tox` instead

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [x] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

[//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://preview.redd.it/kc0fmcvq1mg41.png?auto=webp&s=180dfcbac2ada6793fd5de95a6e260014603c561)
