### PR TITLE
Upgrade isort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint:
 	tox -elint
 
 lint-roll:
-	isort --recursive <MODULE_NAME> tests
+	isort <MODULE_NAME> tests
 	black {toxinidir}/<MODULE_NAME> {toxinidir}/tests setup.py
 	$(MAKE) lint
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ lint:
 
 lint-roll:
 	isort <MODULE_NAME> tests
-	black {toxinidir}/<MODULE_NAME> {toxinidir}/tests setup.py
+	black <MODULE_NAME> tests setup.py
 	$(MAKE) lint
 
 test:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
     ],
     "lint": [
         "flake8==3.7.9",
-        "isort>=4.2.15,<5",
+        "isort>=5.10.1,<6",
         "mypy==0.770",
         "pydocstyle>=5.0.0,<6",
         "black>=22,<23",

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,9 @@ envlist=
 [isort]
 combine_as_imports=True
 force_sort_within_sections=True
-include_trailing_comma=True
 known_third_party=hypothesis,pytest
 known_first_party=<MODULE_NAME>
-line_length=21
-multi_line_output=3
-use_parentheses=True
+profile=black
 
 [flake8]
 max-line-length= 100
@@ -42,6 +39,6 @@ extras=lint
 commands=
     mypy -p <MODULE_NAME> --config-file {toxinidir}/mypy.ini
     flake8 {toxinidir}/<MODULE_NAME> {toxinidir}/tests
-    isort --recursive --check-only --diff {toxinidir}/<MODULE_NAME> {toxinidir}/tests
+    isort --check-only --diff {toxinidir}/<MODULE_NAME> {toxinidir}/tests
     pydocstyle --explain {toxinidir}/<MODULE_NAME> {toxinidir}/tests
     black --check {toxinidir}/<MODULE_NAME> {toxinidir}/tests setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ profile=black
 [flake8]
 max-line-length= 100
 exclude= venv*,.tox,docs,build
-ignore=
+extend-ignore= E203
 
 [testenv]
 usedevelop=True
@@ -36,6 +36,7 @@ whitelist_externals=make
 [testenv:lint]
 basepython=python
 extras=lint
+whitelist_externals=black
 commands=
     mypy -p <MODULE_NAME> --config-file {toxinidir}/mypy.ini
     flake8 {toxinidir}/<MODULE_NAME> {toxinidir}/tests


### PR DESCRIPTION
## What was wrong?

#65 added black, but missed an `isort` upgrade. [`black` requires isort v5](https://pycqa.github.io/isort/docs/configuration/black_compatibility.html).

## How was it fixed?

Upgrade isort to v5, [drop the `--recursive` flag](https://pycqa.github.io/isort/docs/upgrade_guides/5.0.0.html#-recursive-or-rc), plus a minor cleanup to flake8 and tox.

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

[//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://i.dailymail.co.uk/i/pix/2015/07/06/11/2A449CA500000578-3150831-Skills_In_November_2013_Miss_Forrester_bought_a_shape_sorter_for-a-10_1436178110551.jpg)
