### PR TITLE
Add Python 3.11, add more black checks, remove upper pins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,12 @@ jobs:
       - image: cimg/python:3.10
         environment:
           TOXENV: py310-core
+  py311-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-core
   pypy3-core:
     <<: *common
     docker:
@@ -88,4 +94,5 @@ workflows:
       - py38-core
       - py39-core
       - py310-core
+      - py311-core
       - pypy3-core

--- a/setup.py
+++ b/setup.py
@@ -7,25 +7,25 @@ from setuptools import (
 
 extras_require = {
     "test": [
-        "pytest>=6.2.5,<7",
+        "pytest>=6.2.5",
         "pytest-xdist>=2.4.0,<3",
         "tox==3.14.6",
     ],
     "lint": [
         "flake8==3.7.9",
-        "isort>=5.10.1,<6",
+        "isort>=5.10.1",
         "mypy==0.770",
-        "pydocstyle>=5.0.0,<6",
-        "black>=22,<23",
+        "pydocstyle>=5.0.0",
+        "black>=22",
     ],
     "doc": [
-        "Sphinx>=1.6.5,<2",
-        "sphinx_rtd_theme>=0.1.9,<1",
-        "towncrier>=21,<22",
+        "Sphinx>=1.6.5",
+        "sphinx_rtd_theme>=0.1.9",
+        "towncrier>=21",
     ],
     "dev": [
-        "bumpversion>=0.5.3,<1",
-        "pytest-watch>=4.1.0,<5",
+        "bumpversion>=0.5.3",
+        "pytest-watch>=4.1.0",
         "wheel",
         "twine",
         "ipython",
@@ -56,7 +56,7 @@ setup(
     url="https://github.com/ethereum/<REPO_NAME>",
     include_package_data=True,
     install_requires=[
-        "eth-utils>=2,<3",
+        "eth-utils>=2",
     ],
     python_requires=">=3.7, <4",
     extras_require=extras_require,
@@ -78,6 +78,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{37,38,39,310,py3}-core
+    py{37,38,39,310,311,py3}-core
     lint
     docs
 
@@ -27,6 +27,7 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
     pypy3: pypy3
 extras=
     test
@@ -42,4 +43,4 @@ commands=
     flake8 {toxinidir}/<MODULE_NAME> {toxinidir}/tests
     isort --check-only --diff {toxinidir}/<MODULE_NAME> {toxinidir}/tests
     pydocstyle --explain {toxinidir}/<MODULE_NAME> {toxinidir}/tests
-    black --check {toxinidir}/<MODULE_NAME> {toxinidir}/tests setup.py
+    black --check {toxinidir}/<MODULE_NAME> {toxinidir}/docs {toxinidir}/tests {toxinidir}/setup.py


### PR DESCRIPTION
## What was wrong?

- Python 3.11 is out
- `black` command wasn't quite complete
- We've also decided to try out removing upper pins on dependencies

## How was it fixed?

Added CI checks for Python 3.11, added new directories/files for the `black` check, removed upper pins

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

[//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://t4.ftcdn.net/jpg/03/61/06/53/360_F_361065322_GbRFNq23hXuhgxiGD5k35L3b6qnBHhdO.jpg)
