### PR TITLE
Do not invoke `setup.py` directly; minor refactor + cleanup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,13 @@
-## What was wrong?
+### What was wrong?
 
-Issue #
+Related to issue #
 
-## How was it fixed?
-
-Summary of approach.
+### How was it fixed?
 
 ### To-Do
 
 [//]: # (Stay ahead of things, add list items here!)
 - [ ] Clean up commit history
-
-[//]: # (For important changes that should go into the release notes please add a newsfragment file as explained here: https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)
 
 [//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
 - [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean-pyc:
 	find . -name '__pycache__' -exec rm -rf {} +
 
 lint:
-	tox -elint
+	tox -e lint
 
 lint-roll:
 	isort --recursive <MODULE_NAME> tests
@@ -83,11 +83,11 @@ release: check-bump clean
 	git config commit.gpgSign true
 	bumpversion $(bump)
 	git push upstream && git push upstream --tags
-	python setup.py sdist bdist_wheel
+	python -m build
 	twine upload dist/*
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 
 
 dist: clean
-	python setup.py sdist bdist_wheel
+	python -m build
 	ls -l dist

--- a/newsfragments/70.internal.rst
+++ b/newsfragments/70.internal.rst
@@ -1,0 +1,1 @@
+Do not invoke ``setup.py`` directly. Minor cleanup and refactors in newsfragment ``README.md`` and newsfragment validation. Minot cleanup in ``Makefile``.

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -6,7 +6,7 @@ commit message and PR description, which are a description of the change as
 relevant to people working on the code itself.)
 
 Each file should be named like `<ISSUE>.<TYPE>.rst`, where
-`<ISSUE>` is an issue numbers, and `<TYPE>` is one of:
+`<ISSUE>` is an issue number, and `<TYPE>` is one of:
 
 * `feature`
 * `bugfix`
@@ -24,5 +24,5 @@ then open up the PR first and use the PR number for the newsfragment.
 
 Note that the `towncrier` tool will automatically
 reflow your text, so don't try to do any fancy formatting. Run
- `towncrier build --draft` to get a preview of what the release notes entry
+`towncrier build --draft` to get a preview of what the release notes entry
  will look like in the final release notes.

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -8,19 +8,19 @@ import pathlib
 import sys
 
 ALLOWED_EXTENSIONS = {
-    '.breaking.rst',
-    '.bugfix.rst',
-    '.doc.rst',
-    '.feature.rst',
-    '.internal.rst',
-    '.misc.rst',
-    '.performance.rst',
-    '.removal.rst',
+    ".breaking.rst",
+    ".bugfix.rst",
+    ".doc.rst",
+    ".feature.rst",
+    ".internal.rst",
+    ".misc.rst",
+    ".performance.rst",
+    ".removal.rst",
 }
 
 ALLOWED_FILES = {
-    'validate_files.py',
-    'README.md',
+    "validate_files.py",
+    "README.md",
 }
 
 THIS_DIR = pathlib.Path(__file__).parent
@@ -28,7 +28,7 @@ THIS_DIR = pathlib.Path(__file__).parent
 num_args = len(sys.argv) - 1
 assert num_args in {0, 1}
 if num_args == 1:
-    assert sys.argv[1] in ('is-empty', )
+    assert sys.argv[1] in ("is-empty",)
 
 for fragment_file in THIS_DIR.iterdir():
 
@@ -38,7 +38,9 @@ for fragment_file in THIS_DIR.iterdir():
         full_extension = "".join(fragment_file.suffixes)
         if full_extension not in ALLOWED_EXTENSIONS:
             raise Exception(f"Unexpected file: {fragment_file}")
-    elif sys.argv[1] == 'is-empty':
+    elif sys.argv[1] == "is-empty":
         raise Exception(f"Unexpected file: {fragment_file}")
     else:
-        raise RuntimeError("Strange: arguments {sys.argv} were validated, but not found")
+        raise RuntimeError(
+            f"Strange: arguments {sys.argv} were validated, but not found"
+        )


### PR DESCRIPTION
### What was wrong?

- Remove double link to the newsfragment `README.md` in the github PR template
- Minor cleanup and refactor
- Do not invoke ``setup.py`` directly: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

### To-Do

- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![SSPX0409](https://user-images.githubusercontent.com/3532824/203186606-cc44888e-aa35-43c1-b452-e172240dc5c8.jpg)
