### PR TITLE
Fix auto project template errors for MacOS

### DIFF
--- a/.project-template/fill_template_vars.sh
+++ b/.project-template/fill_template_vars.sh
@@ -33,7 +33,7 @@ _replace() {
   local find_cmd=(find "$PROJECT_ROOT" ! -perm -u=x ! -path '*/.git/*' ! -path '*/venv*/*' -type f)
 
   if [[ $(uname) == Darwin ]]; then
-    "${find_cmd[@]}" -exec sed -i '' "$1" {} +
+    LC_ALL=C "${find_cmd[@]}" -exec sed -i '' "$1" {} +
   else
     "${find_cmd[@]}" -exec sed -i "$1" {} +
   fi

--- a/.project-template/refill_template_vars.sh
+++ b/.project-template/refill_template_vars.sh
@@ -1,2 +1,2 @@
-TEMPLATE_DIR=$(dirname $(readlink -f "$0"))
+TEMPLATE_DIR=$(dirname "$0")
 <"$TEMPLATE_DIR/template_vars.txt" "$TEMPLATE_DIR/fill_template_vars.sh"


### PR DESCRIPTION
### What was wrong?
The template variables script wasn't working quite right with mac. 
- `readlink` doesn't accept the `-f` flag 
- `sed` was throwing an illegal byte sequence error

### How was it fixed?
change `readlink` to `dirname`, forced `LC_ALL=C` on the `sed` command

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.shutterstock.com/image-photo/female-cougar-kitten-puma-concolor-260nw-391202839.jpg)
