### PR TITLE
Update isort CLI flags

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,11 @@ envlist=
 
 [isort]
 combine_as_imports=True
+force_grid_wrap=1
 force_sort_within_sections=True
 known_third_party=hypothesis,pytest
 known_first_party=<MODULE_NAME>
+multi_line_output=3
 profile=black
 
 [flake8]


### PR DESCRIPTION
### What was wrong?
isort v5 made some changes to their defaults. This PR makes it so we can standardize without drastically changing imports across all libraries.


### How was it fixed?
Added CLI flags that most closely align with our current isort pattern

### To-Do

[//]: # (Stay ahead of things, add list items here!)
- [ ] Clean up commit history

[//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![put a cute animal picture link inside the parentheses](https://www.shutterstock.com/image-photo/female-cougar-kitten-puma-concolor-260nw-422731798.jpg)
