### PR TITLE
bump docs dependencies

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,5 @@
+version: 2
+
+python:
+  install:
+  - requirements: requirements-docs.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
+    "sphinx_rtd_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/newsfragments/70.internal.rst
+++ b/newsfragments/70.internal.rst
@@ -1,1 +1,0 @@
-Do not invoke ``setup.py`` directly. Minor cleanup and refactors in newsfragment ``README.md`` and newsfragment validation. Minot cleanup in ``Makefile``.

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ extras_require = {
         "black>=22",
     ],
     "doc": [
-        "Sphinx>=1.6.5",
-        "sphinx_rtd_theme>=0.1.9",
-        "towncrier>=21",
+        "sphinx>=5.0.0",
+        "sphinx_rtd_theme>=1.0.0",
+        "towncrier>=21,<22",
     ],
     "dev": [
         "bumpversion>=0.5.3",


### PR DESCRIPTION
### What was wrong?

Docs dependencies are older, bumping

[//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
- [x] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/229614795-5541bd4f-0849-444e-b321-61be4e40c047.png)
