### PR TITLE
Various template default updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
   docs:
     <<: *common
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
         environment:
           TOXENV: docs
   py37-lint:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,57 +42,78 @@ jobs:
       - image: cimg/python:3.7
         environment:
           TOXENV: docs
-  lint:
+  py37-lint:
     <<: *common
     docker:
       - image: cimg/python:3.7
         environment:
-          TOXENV: lint
+          TOXENV: py37-lint
   py37-core:
     <<: *common
     docker:
       - image: cimg/python:3.7
         environment:
           TOXENV: py37-core
+  py38-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.8
+        environment:
+          TOXENV: py38-lint
   py38-core:
     <<: *common
     docker:
       - image: cimg/python:3.8
         environment:
           TOXENV: py38-core
+  py39-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.9
+        environment:
+          TOXENV: py39-lint
   py39-core:
     <<: *common
     docker:
       - image: cimg/python:3.9
         environment:
           TOXENV: py39-core
+  py310-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.10
+        environment:
+          TOXENV: py310-lint
   py310-core:
     <<: *common
     docker:
       - image: cimg/python:3.10
         environment:
           TOXENV: py310-core
+  py311-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-lint
   py311-core:
     <<: *common
     docker:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-core
-  pypy3-core:
-    <<: *common
-    docker:
-      - image: pypy
-        environment:
-          TOXENV: pypy3-core
 workflows:
   version: 2
   test:
     jobs:
       - docs
-      - lint
+      - py37-lint
+      - py38-lint
+      - py39-lint
+      - py310-lint
+      - py311-lint
       - py37-core
       - py38-core
       - py39-core
       - py310-core
       - py311-core
-      - pypy3-core

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,8 +9,6 @@ Related to issue #
 [//]: # (Stay ahead of things, add list items here!)
 - [ ] Clean up commit history
 
-- [ ] Update any affected documentation
-
 [//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
 - [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,8 @@ Related to issue #
 [//]: # (Stay ahead of things, add list items here!)
 - [ ] Clean up commit history
 
+- [ ] Update any affected documentation
+
 [//]: # (See: https://<RTD_NAME>.readthedocs.io/en/latest/contributing.html#pull-requests)
 - [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,4 +2,7 @@ version: 2
 
 python:
   install:
-  - requirements: requirements-docs.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,1 +1,0 @@
-<PYPI_NAME>[doc]

--- a/setup.py
+++ b/setup.py
@@ -7,14 +7,14 @@ from setuptools import (
 
 extras_require = {
     "test": [
-        "pytest>=6.2.5",
-        "pytest-xdist>=2.4.0,<3",
-        "tox==3.14.6",
+        "pytest>=7.0.0",
+        "pytest-xdist>=2.4.0",
+        "tox>=3.18.0",
     ],
     "lint": [
-        "flake8==3.7.9",
+        "flake8==3.8.2",
         "isort>=5.10.1",
-        "mypy==0.770",
+        "mypy==0.971",
         "pydocstyle>=5.0.0",
         "black>=22",
     ],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ extras_require = {
         "pytest-xdist>=2.4.0",
     ],
     "lint": [
-        "flake8==3.8.2",
+        "flake8>=5.0.0",
+        "flake8-bugbear>=22.0.0",
         "isort>=5.10.1",
         "mypy==0.971",
         "pydocstyle>=5.0.0",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ extras_require = {
     "test": [
         "pytest>=7.0.0",
         "pytest-xdist>=2.4.0",
-        "tox>=3.18.0",
     ],
     "lint": [
         "flake8==3.8.2",
@@ -26,6 +25,7 @@ extras_require = {
     "dev": [
         "bumpversion>=0.5.3",
         "pytest-watch>=4.1.0",
+        "tox>=3.18.0",
         "wheel",
         "twine",
         "ipython",

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,5 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: Implementation :: PyPy",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{37,38,39,310,311,py3}-core
-    lint
+    py{37,38,39,310,311}-core
+    py{37,38,39,310,311}-lint
     docs
 
 [isort]
@@ -14,7 +14,7 @@ multi_line_output=3
 profile=black
 
 [flake8]
-max-line-length= 100
+max-line-length= 88
 exclude= venv*,.tox,docs,build
 extend-ignore= E203
 
@@ -30,19 +30,27 @@ basepython =
     py39: python3.9
     py310: python3.10
     py311: python3.11
-    pypy3: pypy3
 extras=
     test
     docs: doc
-whitelist_externals=make
+allowlist_externals=make
 
-[testenv:lint]
+[common-lint]
 basepython=python
 extras=lint
-whitelist_externals=black
+allowlist_externals=black
 commands=
     mypy -p <MODULE_NAME> --config-file {toxinidir}/mypy.ini
     flake8 {toxinidir}/<MODULE_NAME> {toxinidir}/tests
     isort --check-only --diff {toxinidir}/<MODULE_NAME> {toxinidir}/tests
     pydocstyle --explain {toxinidir}/<MODULE_NAME> {toxinidir}/tests
     black --check {toxinidir}/<MODULE_NAME> {toxinidir}/docs {toxinidir}/tests {toxinidir}/setup.py
+
+[testenv:lint]
+basepython: python
+extras: {[common-lint]extras}
+commands: {[common-lint]commands}
+
+[testenv:py{37,38,39,310,311}-lint]
+extras: {[common-lint]extras}
+commands: {[common-lint]commands}


### PR DESCRIPTION
### What was wrong?

Some template defaults have fallen behind on common settings used across our libs. Updating.

Moving `tox` to `setup.py[dev]` closes #34

Moving doc build requirements info `.readthedocs.yml` closes #40 

Adding `flake8-bugbear` closes #35

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/229641206-a78105bd-b6d6-477f-a06a-c6e8547cc162.png)
