### PR TITLE
remove outdated sections of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # <PROJECT_NAME>
 
-[![Join the chat at https://gitter.im/ethereum/<REPO_NAME>](https://badges.gitter.im/ethereum/<REPO_NAME>.svg)](https://gitter.im/ethereum/<REPO_NAME>?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://circleci.com/gh/ethereum/<REPO_NAME>.svg?style=shield)](https://circleci.com/gh/ethereum/<REPO_NAME>)
 [![PyPI version](https://badge.fury.io/py/<PYPI_NAME>.svg)](https://badge.fury.io/py/<PYPI_NAME>)
 [![Python versions](https://img.shields.io/pypi/pyversions/<PYPI_NAME>.svg)](https://pypi.python.org/pypi/<PYPI_NAME>)
@@ -40,39 +39,7 @@ virtualenv -p python3 venv
 pip install -e .[dev]
 ```
 
-### Testing Setup
-
-During development, you might like to have tests run on every file save.
-
-Show flake8 errors on file change:
-
-```sh
-# Test flake8
-when-changed -v -s -r -1 <MODULE_NAME>/ tests/ -c "clear; flake8 <MODULE_NAME> tests && echo 'flake8 success' || echo 'error'"
-```
-
-Run multi-process tests in one command, but without color:
-
-```sh
-# in the project root:
-pytest --numprocesses=4 --looponfail --maxfail=1
-# the same thing, succinctly:
-pytest -n 4 -f --maxfail=1
-```
-
-Run in one thread, with color and desktop notifications:
-
-```sh
-cd venv
-ptw --onfail "notify-send -t 5000 'Test failure ⚠⚠⚠⚠⚠' 'python 3 test on <REPO_NAME> failed'" ../tests ../<MODULE_NAME>
-```
-
 ### Release setup
-
-For Debian-like systems:
-```
-apt install pandoc
-```
 
 To release a new version:
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ git clone git@github.com:ethereum/<REPO_NAME>.git
 cd <REPO_NAME>
 virtualenv -p python3 venv
 . venv/bin/activate
-pip install -e .[dev]
+pip install -e ".[dev]"
 ```
 
 ### Release setup


### PR DESCRIPTION
### What was wrong?

README had outdated references

Closes issue #38 

### How was it fixed?

Removed reference to gitter, testing setup section, and requirement for `pandoc` to cut a release.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/230215626-16a7b781-ed12-4626-8eea-0e934db25dca.png)
