### PR TITLE
repin flake8 and misc updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-core
+
 workflows:
   version: 2
   test:

--- a/.project-template/fill_template_vars.py
+++ b/.project-template/fill_template_vars.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 def _find_files(project_root):
-    path_exclude_pattern = r"\.git($|\/)|venv|_build"
+    path_exclude_pattern = r"\.git($|\/)|venv|_build|\.tox"
     file_exclude_pattern = r"fill_template_vars\.py|\.swp$"
     filepaths = []
     for dir_path, _dir_names, file_names in os.walk(project_root):

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include LICENSE
 include README.md
-include requirements-docs.txt
 
 global-include *.pyi
 

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ extras_require = {
         "pytest-xdist>=2.4.0",
     ],
     "lint": [
-        "flake8>=5.0.0",
-        "flake8-bugbear>=22.0.0",
+        "flake8==6.0.0",
+        "flake8-bugbear==23.3.23",
         "isort>=5.10.1",
         "mypy==0.971",
         "pydocstyle>=5.0.0",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extras_require = {
     "dev": [
         "bumpversion>=0.5.3",
         "pytest-watch>=4.1.0",
-        "tox>=3.18.0",
+        "tox>=4.0.0",
         "wheel",
         "twine",
         "ipython",

--- a/tox.ini
+++ b/tox.ini
@@ -14,16 +14,16 @@ multi_line_output=3
 profile=black
 
 [flake8]
-max-line-length= 88
-exclude= venv*,.tox,docs,build
-extend-ignore= E203
+max-line-length=88
+exclude=venv*,.tox,docs,build
+extend-ignore=E203
 
 [testenv]
 usedevelop=True
 commands=
     core: pytest {posargs:tests/core}
     docs: make check-docs
-basepython =
+basepython=
     docs: python
     py37: python3.7
     py38: python3.8


### PR DESCRIPTION
### What was wrong?

Repinning `flake8` and `flake8-bugbear` per discussion in #74 
Bumping tox to >=4.0.0, as that's where `whitelist` deprecated for `allowlist`
Minor updates needed, discovered when pulling template into hexbytes library

#### Cute Animal Picture
![image](https://user-images.githubusercontent.com/5199899/230984313-4dc6bb8d-e685-44aa-8058-34048ea7bd79.png)
