### PR TITLE
apply template updates found following merge with eth-typing

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Closes Issue #
 
 - [ ] Add or update documentation related to these changes
 
-- [ ] Add entry to the [release notes](https://github.com/ethereum/web3.py/blob/master/newsfragments/README.md)
+- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)
 
 #### Cute Animal Picture
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ### What was wrong?
 
 Related to Issue #
-Closes Issue #
+Closes #
 
 ### How was it fixed?
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "<PROJECT_NAME>"
-copyright = "2020, The Ethereum Foundation"
+copyright = "2019-2023, The Ethereum Foundation"
 
 __version__ = setup_version
 # The version info for the project you're documenting, acts as replacement for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-# Read https://github.com/ethereum/<REPO_NAME>/newsfragments/README.md for instructions
+# Read https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md for instructions
 package = "<MODULE_NAME>"
 filename = "docs/release_notes.rst"
 directory = "newsfragments"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts= -v --showlocals --durations 10 
+addopts= -v --showlocals --durations 10
 xfail_strict=true
 log_format = %(levelname)8s  %(asctime)s  %(filename)20s  %(message)s
 log_date_format = %m-%d %H:%M:%S

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,6 @@ addopts= -v --showlocals --durations 10
 xfail_strict=true
 log_format = %(levelname)8s  %(asctime)s  %(filename)20s  %(message)s
 log_date_format = %m-%d %H:%M:%S
-timeout = 300
 
 [pytest-watch]
 runner= pytest --failed-first --maxfail=1 --no-success-flaky-report

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
-        "Operating System :: MacOS",
-        "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ extras_require = {
         "bumpversion>=0.5.3",
         "pytest-watch>=4.1.0",
         "tox>=4.0.0",
+        "build>=0.9.0",
         "wheel",
         "twine",
         "ipython",
@@ -59,7 +60,7 @@ setup(
     install_requires=[
         "eth-utils>=2",
     ],
-    python_requires=">=3.7, <4",
+    python_requires=">=3.7.2, <4",
     extras_require=extras_require,
     py_modules=["<MODULE_NAME>"],
     license="MIT",


### PR DESCRIPTION
### What was wrong?

Found more template tweaks while merging with eth-typing. Tweaked them.

External discussion decided to not include `Operating System` classifiers in `setup.py`.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/231830115-105a2476-e1c1-4648-8b94-be1404c9d49d.png)