### PR TITLE
upgrade pip and remove --user from tox install during ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,9 @@ common: &common
           - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
-        command: python -m pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: run tox
         command: python -m tox -r
@@ -50,7 +52,9 @@ windows_steps: &windows_steps
           - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
     - run:
         name: install dependencies
-        command: python -m pip install --user tox
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: run tox
         command: python -m tox -r


### PR DESCRIPTION
### What was wrong?

`virtualenv` dropped python2 support, which revealed a hole in how our CI was building. This fixes that, and upgrades pip every time for good measure.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/234109521-5fd934c9-f255-4fdd-8640-db7f5ddb7203.png)