### PR TITLE
update tox calls to use run, update all pip calls to use python -m

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ common: &common
           python -m pip install tox
     - run:
         name: run tox
-        command: python -m tox -r
+        command: python -m tox run -r
     - save_cache:
         paths:
           - .hypothesis
@@ -57,7 +57,7 @@ windows_steps: &windows_steps
           python -m pip install tox
     - run:
         name: run tox
-        command: python -m tox -r
+        command: python -m tox run -r
     - save_cache:
         paths:
           - .tox

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,6 +65,8 @@ body:
   - type: textarea
     id: pip-freeze
     attributes:
-      label: Output from pip-freeze
-      description: Run `pip-freeze` and paste the output below
+      label: Output from `pip freeze`
+      description: Run `python -m pip freeze` and paste the output below
       render: shell
+    validations:
+      required: false

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ clean-pyc:
 	find . -name '__pycache__' -exec rm -rf {} +
 
 lint:
-	tox -e lint
+	tox run -e lint
 
 lint-roll:
 	isort <MODULE_NAME> tests
@@ -39,7 +39,7 @@ test:
 	pytest tests
 
 test-all:
-	tox
+	tox run
 
 build-docs:
 	sphinx-apidoc -o docs/ . setup.py "*conftest*"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Read more in the [documentation on ReadTheDocs](https://<RTD_NAME>.readthedocs.i
 ## Quickstart
 
 ```sh
-pip install <PYPI_NAME>
+python -m pip install <PYPI_NAME>
 ```
 
 ## Developer Setup
@@ -37,7 +37,7 @@ git clone git@github.com:ethereum/<REPO_NAME>.git
 cd <REPO_NAME>
 virtualenv -p python3 venv
 . venv/bin/activate
-pip install -e ".[dev]"
+python -m pip install -e ".[dev]"
 ```
 
 ### Release setup


### PR DESCRIPTION
### What was wrong?

Calling `tox` without `run` is so `v3`. `v4` likes it to always be `tox run`.  - https://tox.wiki/en/latest/upgrading.html#cli-command-compatibility

Also update all calls to `pip` to use `python -m pip` and fix `pip freeze` reference.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/234379849-71c2b2ab-4a25-492a-a1f4-3b1fae355782.png)