### PR TITLE
Remove testall

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Closes #
 
 - [ ] Add or update documentation related to these changes
 
-- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/master/newsfragments/README.md)
+- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)
 
 #### Cute Animal Picture
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ help:
 	@echo "lint - check style with flake8"
 	@echo "lint-roll - automatically fix problems with isort, flake8, etc"
 	@echo "test - run tests quickly with the default Python"
-	@echo "testall - run tests on every Python version with tox"
 	@echo "docs - generate docs and open in browser (linux-docs for version on linux)"
 	@echo "notes - consume towncrier newsfragments/ and update release notes in docs/"
 	@echo "release - package and upload a release (does not run notes target)"
@@ -37,9 +36,6 @@ lint-roll:
 
 test:
 	pytest tests
-
-test-all:
-	tox run
 
 build-docs:
 	sphinx-apidoc -o docs/ . setup.py "*conftest*"

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -26,4 +26,4 @@ then open up the PR first and use the PR number for the newsfragment.
 Note that the `towncrier` tool will automatically
 reflow your text, so don't try to do any fancy formatting. Run
 `towncrier build --draft` to get a preview of what the release notes entry
- will look like in the final release notes.
+will look like in the final release notes.


### PR DESCRIPTION
### What was wrong?

The `testall` or `test-all` in Makefile doesn't work with the multi-python version setup we have in tox. I'd be down to set up a locally functional version like we have for `lint` if you think that would be useful, but I think that between running just `test` and `lint` locally and creating a PR to run CI, everything is covered.

Also other minor cleanup.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/234941800-eccafce9-e033-4af1-bcd3-f88dbfc8038c.png)