### PR TITLE
bump docs dependencies

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,8 @@
+version: 2
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.intersphinx",
+    "sphinx_rtd_theme",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/newsfragments/70.internal.rst
+++ b/newsfragments/70.internal.rst
@@ -1,1 +1,0 @@
-Do not invoke ``setup.py`` directly. Minor cleanup and refactors in newsfragment ``README.md`` and newsfragment validation. Minot cleanup in ``Makefile``.

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ extras_require = {
         "black>=22",
     ],
     "doc": [
-        "Sphinx>=1.6.5",
-        "sphinx_rtd_theme>=0.1.9",
-        "towncrier>=21",
+        "sphinx>=5.0.0",
+        "sphinx_rtd_theme>=1.0.0",
+        "towncrier>=21,<22",
     ],
     "dev": [
         "bumpversion>=0.5.3",


### PR DESCRIPTION
### What was wrong?

Commit https://github.com/ethereum/ethereum-python-project-template/commit/edb85f7239cea731c0faafe11a0714f580da9994 was signed with a now-deleted gpg key. This re-signs it with a new key.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/235005215-9e3051fe-25ef-4a67-8566-fb3933de3b03.png)