### PR TITLE
bump sphinx version and set py version rtd uses to 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,13 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
+sphinx:
+   configuration: docs/conf.py
+
 python:
   install:
     - method: pip

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras_require = {
         "black>=23",
     ],
     "doc": [
-        "sphinx>=5.0.0",
+        "sphinx>=6.0.0",
         "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
     ],


### PR DESCRIPTION
### What was wrong?

ReadTheDocs builds started failing using their default (3.7) version of python. It was also limiting the version of `sphinx`.

### How was it fixed?

Added additional configuration to `.readthedocs.yml` and bumped the `sphinx` version.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/235986540-5016f273-bf24-4b68-a5a4-4d9f957ee8f2.png)
