### PR TITLE
change references to doc to all be docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,4 +13,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - doc
+        - docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -190,7 +190,7 @@ html_theme = "sphinx_rtd_theme"
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = "<MODULE_NAME>doc"
+htmlhelp_basename = "<MODULE_NAME>docs"
 
 
 # -- Options for LaTeX output ---------------------------------------------

--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -11,7 +11,7 @@ Each file should be named like `<ISSUE>.<TYPE>.rst`, where
 * `breaking`
 * `bugfix`
 * `deprecation`
-* `doc`
+* `docs`
 * `feature`
 * `internal`
 * `misc`

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -10,7 +10,7 @@ ALLOWED_EXTENSIONS = {
     ".breaking.rst",
     ".bugfix.rst",
     ".deprecation.rst",
-    ".doc.rst",
+    ".docs.rst",
     ".feature.rst",
     ".internal.rst",
     ".misc.rst",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ name = "Deprecations"
 showcontent = true
 
 [[tool.towncrier.type]]
-directory = "doc"
+directory = "docs"
 name = "Improved Documentation"
 showcontent = true
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require = {
         "pydocstyle>=6.0.0",
         "black>=23",
     ],
-    "doc": [
+    "docs": [
         "sphinx>=6.0.0",
         "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
@@ -38,7 +38,7 @@ extras_require["dev"] = (
     extras_require["dev"]
     + extras_require["test"]
     + extras_require["lint"]
-    + extras_require["doc"]
+    + extras_require["docs"]
 )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ basepython=
     py311: python3.11
 extras=
     test
-    docs: doc
+    docs
 allowlist_externals=make
 
 [common-lint]


### PR DESCRIPTION
### What was wrong?

References to documentation/documents was sometimes `doc`, sometimes `docs`. Change all to use `docs`.

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/236037055-54d7c77f-e938-45b8-bc50-c39f93bdb710.png)
