### PR TITLE
Add tests to distribution by default

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include LICENSE
 include README.md
 
+recursive-include tests *
+
 global-include *.pyi
 
 recursive-exclude * __pycache__

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ notes: check-bump
 	make build-docs
 	git commit -m "Compile release notes"
 
-release: check-bump clean
+release: check-bump test clean
 	# require that you be on a branch that's linked to upstream/main
 	git status -s -b | head -1 | grep "\.\.upstream/main"
 	# verify that docs build correctly


### PR DESCRIPTION
### What was wrong?

There have been a couple requests to add the `tests/` directory to the `tar.gz`. 

Related to Issue [ethereum/eth-tester#8](https://github.com/ethereum/eth-typing/issues/8), https://github.com/ethereum/eth-utils/issues/130


### How was it fixed?
Added it, and added a test run via `make tests` to the release script. 

I'm not sure the test run will make sense across all releases and all repos, so want to discuss that if anyone feels like that may be overkill. The library I'm thinking of in particular is `web3.py` and `py-evm` where full test runs take ~10 mins.

### Todo:
- [x] Clean up commit history

- [x] Add or update documentation related to these changes

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://npr.brightspotcdn.com/dims4/default/1c702fd/2147483647/strip/true/crop/800x523+0+0/resize/880x575!/quality/90/?url=http%3A%2F%2Fnpr-brightspot.s3.amazonaws.com%2Flegacy%2Fsites%2Fupr%2Ffiles%2F201609%2Ffdbeb085-155d-451f-67503226478ffcd8-large__1_.jpg)