### PR TITLE
Pre-release check for upstream configuration of remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,9 @@ notes: check-bump
 	make build-docs
 	git commit -m "Compile release notes"
 
-release: check-bump test clean
-	# require that you be on a branch that's linked to upstream/main
-	git status -s -b | head -1 | grep "\.\.upstream/main"
+release: check-bump clean
+	# require that upstream is configured for ethereum/<REPO_NAME>
+	git remote -v | grep "upstream\tgit@github.com:ethereum/<REPO_NAME>.git (push)\|upstream\thttps://github.com/ethereum/<REPO_NAME> (push)"
 	# verify that docs build correctly
 	./newsfragments/validate_files.py is-empty
 	make build-docs


### PR DESCRIPTION
### What was wrong?

The release make command was not working, which led to running the tagging/release steps manually.

### How was it fixed?

Changed the command to check the remote upstream is configured. It checks the remote repo configuration with `git remote -v` and greps for the web3.py repo is set as the upstream with ssh or https.

Tested this with a copy of the template repo and the Makefile looks correct.

### Todo:
- [ ] Clean up commit history

- [ ] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://naturallycuriouswithmaryholland.files.wordpress.com/2012/07/7-11-12-great-blue-heron-chicks-yawning-img_9649.jpg)