### PR TITLE
ignore flake8 F401 errors in __init__.py files

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,10 @@ multi_line_output=3
 profile=black
 
 [flake8]
-max-line-length=88
 exclude=venv*,.tox,docs,build
 extend-ignore=E203
+max-line-length=88
+per-file-ignores=__init__.py:F401
 
 [testenv]
 usedevelop=True


### PR DESCRIPTION
### What was wrong?

`__init__.py` files across our libs have `# noqa: F401` on every line that imports something that is not used in that file. Unnecessary!

Closes #101 

### How was it fixed?

Tell flake8 to ignore those errors in `__init__.py` files

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/444c2d3c-466c-441f-86ba-683a1cc3d108)