### PR TITLE
drop py37 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,12 +74,6 @@ jobs:
         environment:
           TOXENV: docs
 
-  py37-core:
-    <<: *common
-    docker:
-      - image: cimg/python:3.7
-        environment:
-          TOXENV: py37-core
   py38-core:
     <<: *common
     docker:
@@ -130,12 +124,6 @@ jobs:
         environment:
           TOXENV: py311-lint
 
-  py37-wheel:
-    <<: *common
-    docker:
-      - image: cimg/python:3.7
-        environment:
-          TOXENV: py37-wheel
   py38-wheel:
     <<: *common
     docker:
@@ -171,17 +159,14 @@ workflows:
   test:
     jobs:
       - docs
-      - py37-core
       - py38-core
       - py39-core
       - py310-core
       - py311-core
-      - py37-lint
       - py38-lint
       - py39-lint
       - py310-lint
       - py311-lint
-      - py37-wheel
       - py38-wheel
       - py39-wheel
       - py310-wheel

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     install_requires=[
         "eth-utils>=2",
     ],
-    python_requires=">=3.7, <4",
+    python_requires=">=3.8, <4",
     extras_require=extras_require,
     py_modules=["<MODULE_NAME>"],
     license="MIT",
@@ -64,7 +64,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{37,38,39,310,311}-core
+    py{38,39,310,311}-core
     py{38,39,310,311}-lint
-    py{37,38,39,310,311}-wheel
+    py{38,39,310,311}-wheel
     py311-wheel-windows
     docs
 
@@ -28,7 +28,6 @@ commands=
     docs: make check-docs
 basepython=
     docs: python
-    py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10
@@ -51,7 +50,7 @@ commands: {[common-lint]commands}
 [testenv:py{38,39,310,311}-lint]
 commands: {[common-lint]commands}
 
-[testenv:py{37,38,39,310,311}-wheel]
+[testenv:py{38,39,310,311}-wheel]
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
### What was wrong?

Python 3.7 support is going away, starting with the template


#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/ae792a8c-e62e-4d70-b2a1-053c6475dc9a)
