### PR TITLE
bump pre-commit to 4.5 and add github-flavored markdown linting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,11 +7,11 @@ Closes #
 
 ### Todo:
 
-- \[ \] Clean up commit history
+- [ ] Clean up commit history
 
-- \[ \] Add or update documentation related to these changes
+- [ ] Add or update documentation related to these changes
 
-- \[ \] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)
+- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)
 
 #### Cute Animal Picture
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: '.project-template|docs/conf.py'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
     -   id: check-toml
@@ -30,6 +30,8 @@ repos:
     rev: 0.7.17
     hooks:
     -   id: mdformat
+        additional_dependencies:
+        -   mdformat-gfm
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.5.1
     hooks:


### PR DESCRIPTION
### What was wrong?

The plain `mdformat` markdown linter backslash-escapes the square brackets that github uses to make checkboxes, which makes them not work correctly. The `mdformat-gfm` extension lets things work correctly.

### How was it fixed?

Added `mdformat-gfm` extension
Bumped `pre-commit` version because bumps.

### Todo:

- [x] Clean up commit history

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/36ec96f7-8118-413c-9cab-3969e3bbd042)
