### PR TITLE
drop egg references

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ common: &common
           - .tox
           - ~/.cache/pip
           - ~/.local
-          - ./eggs
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 orbs:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ clean: clean-build clean-pyc
 clean-build:
 	rm -fr build/
 	rm -fr dist/
-	rm -fr *.egg-info
 
 clean-pyc:
 	find . -name '*.pyc' -exec rm -f {} +


### PR DESCRIPTION
### What was wrong?

We still reference eggs and egg-info, but we use wheels now. 

### How was it fixed?
Removed references from CI and Makefile, left in .gitignore because you never know what someone will have lying around locally.

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/be3730d4-2f6d-4dfb-88d6-a157b61a00e1)
