### PR TITLE
condense tox lint envs as linting now a pre-commit call, not tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,18 +28,10 @@ extras=
     docs
 allowlist_externals=make,pre-commit
 
-[common-lint]
-basepython=python
+[testenv:py{38,39,310,311}-lint]
 deps=pre-commit
 commands=
     pre-commit run --all-files --show-diff-on-failure
-
-[testenv:lint]
-basepython: python
-commands: {[common-lint]commands}
-
-[testenv:py{38,39,310,311}-lint]
-commands: {[common-lint]commands}
 
 [testenv:py{38,39,310,311}-wheel]
 deps=


### PR DESCRIPTION
### What was wrong?

Missed some extraneous tox testenv defs when moving from tox linting to pre-commit.

### How was it fixed?

Dropped unnecessary bits. Verified working in [eth-tester](https://github.com/ethereum/eth-tester/pull/273)

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/9152a841-13ec-4a2f-be89-72ab617259ab)
