### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ notes: check-bump
 	towncrier build --yes --version $(UPCOMING_VERSION)
 	# Before we bump the version, make sure that the towncrier-generated docs will build
 	make build-docs
-	git commit -m "Compile release notes"
+	git commit -m "Compile release notes for v$(UPCOMING_VERSION)"
 
 release: check-bump clean
 	# require that upstream is configured for ethereum/<REPO_NAME>

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,9 @@ notes: check-bump
 
 release: check-bump clean
 	# require that upstream is configured for ethereum/<REPO_NAME>
-	git remote -v | grep "upstream\tgit@github.com:ethereum/<REPO_NAME>.git (push)\|upstream\thttps://github.com/ethereum/<REPO_NAME> (push)"
+	@git remote -v | grep \
+		-e "upstream\tgit@github.com:ethereum/<REPO_NAME>.git (push)" \
+		-Ee "upstream\thttps://(www.)?github.com/ethereum/<REPO_NAME> \(push\)"
 	# verify that docs build correctly
 	./newsfragments/validate_files.py is-empty
 	make build-docs


### PR DESCRIPTION
### What was wrong?

- Sometimes 'www.' is used in the url for cloned repositories via https
- Use the available version variable in the make notes command

Notes for review:

- If anyone uses ssh for cloning over https, please check the command. I tried for my repositories that both include "www." and those that don't and that regex check works in both cases.

### Todo:

- [x] Clean up commit history

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Ftse1.mm.bing.net%2Fth%3Fid%3DOIP.CR5MppaA4b_Vhq4sj4DTZQHaEK%26pid%3DApi&f=1&ipt=3f704d20dcd0e975e39d73ad35a087a9da448c60f96ed65c32e40865adb5be41&ipo=images>)
