### PR TITLE
Further generalize the grep command for remote check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,7 @@ notes: check-bump
 
 release: check-bump clean
 	# require that upstream is configured for ethereum/<REPO_NAME>
-	@git remote -v | grep \
-		-e "upstream\tgit@github.com:ethereum/<REPO_NAME>.git (push)" \
-		-Ee "upstream\thttps://(www.)?github.com/ethereum/<REPO_NAME> \(push\)"
+	@git remote -v | grep -E "upstream\tgit@github.com:ethereum/<REPO_NAME>.git \(push\)|upstream\thttps://(www.)?github.com/ethereum/<REPO_NAME> \(push\)"
 	# verify that docs build correctly
 	./newsfragments/validate_files.py is-empty
 	make build-docs


### PR DESCRIPTION
### What was wrong?

There still seemed to be discrepancy across certain command shell on the updated `grep` command. Let's check this works for everyone.

### How was it fixed?

- Use the more commonly used `|` 'or' separator for the command
