### PR TITLE
Ignore all __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ chains
 .cache
 .pytest_cache
 
+# pycache
+__pycache__/
+
 # Test output logs
 logs
 

--- a/newsfragments/114.internal.rst
+++ b/newsfragments/114.internal.rst
@@ -1,1 +1,0 @@
-Ignore ``__pycache__`` directories in Git.

--- a/newsfragments/114.internal.rst
+++ b/newsfragments/114.internal.rst
@@ -1,0 +1,1 @@
+Ignore ``__pycache__`` directories in Git.


### PR DESCRIPTION
### What was wrong?
`__pycache__` directories sometimes appear when running builds locally. No need to track these.

Related to Issue #
Closes #

### How was it fixed?
Added `__pycache__/` to the gitignore.

### Todo:

- [X] Clean up commit history

- [X] Add or update documentation related to these changes

- [x] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://scontent-atl3-1.xx.fbcdn.net/v/t31.18172-8/288673_10150957832101636_518721950_o.jpg?stp=dst-jpg_p403x403&_nc_cat=108&ccb=1-7&_nc_sid=3c63d6&_nc_ohc=9eq9a97D2-IAX_XODGi&_nc_ht=scontent-atl3-1.xx&edm=AKyz2ToEAAAA&oh=00_AfA122cZwtbDdKIImNTmaZsgJs_enwVmByZh4SvRfKELjA&oe=658C7460)
