### PR TITLE
add formats key to RTD to make downloadable docs available

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,3 +15,6 @@ python:
       path: .
       extra_requirements:
         - docs
+
+# Build all formats for RTD Downloads - htmlzip, pdf, epub
+formats: all


### PR DESCRIPTION
### What was wrong?

Tested in web3 [here](https://github.com/ethereum/web3.py/pull/3153), adding `formats` key to RTD builds downloadable docs.

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/c4a3b9aa-ba6d-4139-b62e-3a6f7c2fc214)
