### PR TITLE
add pyupgrade to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,3 +43,8 @@ repos:
     hooks:
     -   id: mypy
         exclude: tests/
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py38-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@ repos:
     -   id: check-toml
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.15.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py38-plus]
 -   repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:
@@ -43,8 +48,3 @@ repos:
     hooks:
     -   id: mypy
         exclude: tests/
--   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-    -   id: pyupgrade
-        args: [--py38-plus]


### PR DESCRIPTION
### What was wrong?

The `pyupgrade` linting tool handles a ton of syntax updates that would either be missed or require tedious updating.

https://github.com/asottile/pyupgrade

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/1f56b565-3727-4a0d-ae6c-6c600250cbc2)