### PR TITLE
add version to import test

### DIFF
--- a/tests/core/test_import.py
+++ b/tests/core/test_import.py
@@ -1,2 +1,0 @@
-def test_import():
-    import <MODULE_NAME>  # noqa: F401

--- a/tests/core/test_import_and_version.py
+++ b/tests/core/test_import_and_version.py
@@ -1,0 +1,4 @@
+def test_import():
+    import <MODULE_NAME>
+    version = <MODULE_NAME>.__version__
+    assert isinstance(version, str)


### PR DESCRIPTION
### What was wrong?

Version info should be available for all libs.

### How was it fixed?
Added version to the basic import test.

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/64660fbd-7fe8-4be5-a32e-77997d705db1)
