### PR TITLE
add py312 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,12 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-core
+  py312-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-core
 
   py38-lint:
     <<: *common
@@ -119,6 +125,12 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-lint
+  py312-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-lint
 
   py38-wheel:
     <<: *common
@@ -144,6 +156,12 @@ jobs:
       - image: cimg/python:3.11
         environment:
           TOXENV: py311-wheel
+  py312-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-wheel
 
   py311-wheel-windows:
     <<: *windows_steps
@@ -159,12 +177,15 @@ workflows:
       - py39-core
       - py310-core
       - py311-core
+      - py312-core
       - py38-lint
       - py39-lint
       - py310-lint
       - py311-lint
+      - py312-lint
       - py38-wheel
       - py39-wheel
       - py310-wheel
       - py311-wheel
+      - py312-wheel
       - py311-wheel-windows

--- a/setup.py
+++ b/setup.py
@@ -67,5 +67,6 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{38,39,310,311}-core
-    py{38,39,310,311}-lint
-    py{38,39,310,311}-wheel
+    py{38,39,310,311,312}-core
+    py{38,39,310,311,312}-lint
+    py{38,39,310,311,312}-wheel
     py311-wheel-windows
     docs
 
@@ -23,18 +23,19 @@ basepython=
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 extras=
     test
     docs
 allowlist_externals=make,pre-commit
 
-[testenv:py{38,39,310,311}-lint]
+[testenv:py{38,39,310,311,312}-lint]
 deps=pre-commit
 commands=
     pre-commit install    
     pre-commit run --all-files --show-diff-on-failure
 
-[testenv:py{38,39,310,311}-wheel]
+[testenv:py{38,39,310,311,312}-wheel]
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
Python 3.12 is here (has been for a bit actually)

### Todo:

- [ ] Clean up commit history

- [ ] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/c775399f-2474-49b4-857f-682cd8cae05d)
