### PR TITLE
add docs build path for ci to check pdf and epub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,10 +84,20 @@ windows-wheel-steps:
       paths:
         - .tox
       key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+        
+docs: &docs
+  docker:
+    - image: common
+  steps:
+    - run:
+        name: install latexpdf dependencies
+        command: |
+          sudo apt-get update
+          sudo apt-get install latexmk tex-gyre texlive-fonts-extra
 
 jobs:
   docs:
-    <<: *common
+    <<: *docs
     docker:
       - image: cimg/python:3.8
         environment:

--- a/Makefile
+++ b/Makefile
@@ -38,12 +38,18 @@ build-docs:
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(MAKE) -C docs doctest
+	
+build-docs-ci:
+	$(MAKE) -C docs latexpdf
+	$(MAKE) -C docs epub
 
-validate-docs:
+validate-newsfragments:
 	python ./newsfragments/validate_files.py
 	towncrier build --draft --version preview
 
-check-docs: build-docs validate-docs
+check-docs: build-docs validate-newsfragments
+
+check-docs-ci: build-docs build-docs-ci validate-newsfragments
 
 docs: check-docs
 	open docs/_build/html/index.html

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ per-file-ignores=__init__.py:F401
 usedevelop=True
 commands=
     core: pytest {posargs:tests/core}
-    docs: make check-docs
+    docs: make check-docs-ci
 basepython=
     docs: python
     windows-wheel: python


### PR DESCRIPTION
### What was wrong?

We build html, pdf, and epub docs off of `main` branch, so we should check that they build correctly in CI as well. Local requirements for building latex are pretty hefty, so only build them in CI.

### How was it fixed?

Created a separate path in `Makefile` to build locally vs building in CI



#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/aee225ca-01bb-4a92-8547-da5214b10f85)
