### PR TITLE
`blocklint` code linting for non-inclusive language

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,8 @@ repos:
     hooks:
     -   id: mypy
         exclude: tests/
+-   repo: https://github.com/PrincetonUniversity/blocklint
+    rev: v0.2.4
+    hooks:
+    -   id: blocklint
+        exclude: 'docs/Makefile|docs/release_notes.rst|tox.ini'

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,9 @@ extend-ignore=E203
 max-line-length=88
 per-file-ignores=__init__.py:F401
 
+[blocklint]
+max_issue_threshold=1
+
 [testenv]
 usedevelop=True
 commands=


### PR DESCRIPTION
### What was wrong?

Related to Issue ethereum/web3.py#3119


### How was it fixed?

Added `blocklint` to check for non-inclusive terminology in codebases.

#### Cute Animal Picture

<img width="394" alt="Screen Shot 2024-03-13 at 3 44 44 PM" src="https://github.com/ethereum/ethereum-python-project-template/assets/435903/e9107e50-3158-48d2-816b-03278d342d5b">


