### PR TITLE
update isort config and multi-platform grepping in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ notes: check-bump validate-newsfragments
 
 release: check-bump clean
 	# require that upstream is configured for ethereum/<REPO_NAME>
-	@git remote -v | grep -E "upstream\tgit@github.com:ethereum/<REPO_NAME>.git \(push\)|upstream\thttps://(www.)?github.com/ethereum/<REPO_NAME> \(push\)"
+	@git remote -v | grep "upstream[[:space:]]git@github.com:ethereum/<REPO_NAME>.git (push)\|upstream[[:space:]]https://github.com/ethereum/<REPO_NAME> (push)"
 	# verify that docs build correctly
 	./newsfragments/validate_files.py is-empty
 	make build-docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,28 +1,30 @@
 [tool.autoflake]
-remove_all_unused_imports = true
 exclude = "__init__.py"
+remove_all_unused_imports = true
 
 [tool.isort]
 combine_as_imports = true
 extra_standard_library = "pytest"
 force_grid_wrap = 1
 force_sort_within_sections = true
-known_third_party = "hypothesis,pytest"
+honor_noqa = true
 known_first_party = "<MODULE_NAME>"
+known_third_party = "hypothesis"
 multi_line_output = 3
 profile = "black"
+use_parentheses = true
 
 [tool.mypy]
 check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_untyped_defs = true
 disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = true
-disallow_subclassing_any = true
+disallow_untyped_defs = true
 ignore_missing_imports = true
-strict_optional = true
 strict_equality = true
+strict_optional = true
 warn_redundant_casts = true
 warn_return_any = true
 warn_unused_configs = true
@@ -63,18 +65,18 @@ add-ignore = "D200,D203,D204,D205,D212,D302,D400,D401,D412,D415"
 
 [tool.pytest.ini_options]
 addopts = "-v --showlocals --durations 10"
-xfail_strict = true
-log_format = "%(levelname)8s  %(asctime)s  %(filename)20s  %(message)s"
 log_date_format = "%m-%d %H:%M:%S"
+log_format = "%(levelname)8s  %(asctime)s  %(filename)20s  %(message)s"
+xfail_strict = true
 
 [tool.towncrier]
 # Read https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md for instructions
-package = "<MODULE_NAME>"
-filename = "docs/release_notes.rst"
 directory = "newsfragments"
-underlines = ["-", "~", "^"]
-title_format = "<REPO_NAME> v{version} ({project_date})"
+filename = "docs/release_notes.rst"
 issue_format = "`#{issue} <https://github.com/ethereum/<REPO_NAME>/issues/{issue}>`__"
+package = "<MODULE_NAME>"
+title_format = "<REPO_NAME> v{version} ({project_date})"
+underlines = ["-", "~", "^"]
 
 [[tool.towncrier.type]]
 directory = "breaking"


### PR DESCRIPTION
### What was wrong?

Update `isort` config.
Update `grep` line in release process to work on both Mac and Linux.
Sort config options withing `pyproject.toml` sections.

Closes #123 
Closes #110 

### How was it fixed?

### Todo:

- [ ] Clean up commit history

- [ ] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/c1aecd7b-b9c9-47a3-8191-c1e7f3f1b80f)
