### PR TITLE
set default ci core tests to just run 'pytest tests'

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ max_issue_threshold=1
 [testenv]
 usedevelop=True
 commands=
-    core: pytest {posargs:tests/core}
+    core: pytest {posargs:tests}
     docs: make check-docs-ci
 basepython=
     docs: python


### PR DESCRIPTION
### What was wrong?

Many libs have a different testing structure that just `tests/core`, but because that is the default CI test path, template updates often mess up testing.

### How was it fixed?

Set CI to run `pytest tests` by default.

### Todo:

- [ ] Clean up commit history

- [ ] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/ae4415f0-eccb-430a-98f4-b85aa1182bdc)
