### PR TITLE
add lint check for .rst files incorrectly placed in the top-level dir

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,15 @@ repos:
     -   id: mypy
         exclude: tests/
 -   repo: https://github.com/PrincetonUniversity/blocklint
-    rev: v0.2.4
+    rev: v0.2.5
     hooks:
     -   id: blocklint
         exclude: 'docs/Makefile|docs/release_notes.rst|tox.ini'
+-   repo: local
+    hooks:
+    -   id: check-rst-files
+        name: Check for .rst files in the top-level directory
+        entry: sh -c 'ls *.rst 1>/dev/null 2>&1 && { echo "found .rst file in top-level folder"; exit 1; } || exit 0'
+        language: system
+        always_run: true
+        pass_filenames: false


### PR DESCRIPTION
also bump blocklint version

### What was wrong?

**someone** keeps putting newsfragment `.rst` files in the top-level dir. This hook will have `pre-commit` fail if it finds any `.rst` files there.

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/a2a5fcc5-b1b9-4ead-904f-0c43a2897bb7)
