### PR TITLE
`sphinx-autobuild` for live docs updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
   docs:
     <<: *docs
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.9
         environment:
           TOXENV: docs
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 sphinx:
   configuration: docs/conf.py

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ help:
 	@echo "lint - fix linting issues with pre-commit"
 	@echo "test - run tests quickly with the default Python"
 	@echo "docs - generate docs and open in browser (linux-docs for version on linux)"
+	@echo "autobuild-docs - live update docs when changes are saved"
 	@echo "notes - consume towncrier newsfragments/ and update release notes in docs/"
 	@echo "release - package and upload a release (does not run notes target)"
 	@echo "dist - package"
@@ -32,6 +33,9 @@ lint:
 
 test:
 	pytest tests
+
+autobuild-docs:
+	sphinx-autobuild --open-browser docs docs/_build/html
 
 build-docs:
 	sphinx-apidoc -o docs/ . setup.py "*conftest*"

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ extras_require = {
     ],
     "docs": [
         "sphinx>=6.0.0",
+        "sphinx-autobuild>=2021.3.14",
         "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
     ],

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ extras_require = {
     ],
     "docs": [
         "sphinx>=6.0.0",
-        "sphinx-autobuild>=2021.3.14",
+        "sphinx-autobuild>=2024.2.4",
         "sphinx_rtd_theme>=1.0.0",
         "towncrier>=21,<22",
     ],


### PR DESCRIPTION
### What was wrong?

Inconvenient to run `make docs` when doing rapid change cycles.

### How was it fixed?

Added Make command `autobuild-docs` to run `sphinx-autobuild`.

### Todo:

- [X] Clean up commit history

#### Cute Animal Picture

<img width="398" alt="Screen Shot 2024-04-12 at 3 34 21 PM" src="https://github.com/ethereum/ethereum-python-project-template/assets/435903/5385142a-581d-4cd5-91f7-bb9babc84cd5">
