### PR TITLE
`scripts` directory included in dist but not in wheel.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.md
 
+recursive-include scripts *
 recursive-include tests *
 
 global-include *.pyi

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
     license="MIT",
     zip_safe=False,
     keywords="ethereum",
-    packages=find_packages(exclude=["tests", "tests.*"]),
+    packages=find_packages(exclude=["scripts", "tests", "tests.*"]),
     package_data={"<MODULE_NAME>": ["py.typed"]},
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

Defaults for the `scripts` directory to be included as part of the distribution but not the wheel.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
