### PR TITLE
Add Tox run to docs CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,16 +84,34 @@ windows-wheel-steps:
       paths:
         - .tox
       key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
-        
+
 docs: &docs
-  docker:
-    - image: common
+  working_directory: ~/repo
   steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: |
+          python -m pip install --upgrade pip
+          python -m pip install tox
     - run:
         name: install latexpdf dependencies
         command: |
           sudo apt-get update
           sudo apt-get install latexmk tex-gyre texlive-fonts-extra
+    - run:
+        name: run tox
+        command: python -m tox run -r
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+        key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+  resource_class: xlarge
 
 jobs:
   docs:


### PR DESCRIPTION
### What was wrong?
Docs on CI were installing dependencies but not testing anything.

### How was it fixed?
Added `tox run -r` to the CI config.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://cff2.earth.com/uploads/2017/10/22055324/PYGMY-MARMOSET-MONKEY.jpg)
