### PR TITLE
switch to xelatex for building latexpdf as it supports more unicode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ docs: &docs
         name: install latexpdf dependencies
         command: |
           sudo apt-get update
-          sudo apt-get install latexmk tex-gyre texlive-fonts-extra
+          sudo apt-get install latexmk tex-gyre texlive-fonts-extra texlive-xetex xindy
     - run:
         name: run tox
         command: python -m tox run -r

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # <PROJECT_NAME> documentation build configuration file, created by
 # sphinx-quickstart on Thu Oct 16 20:43:24 2014.
 #
@@ -194,6 +192,8 @@ htmlhelp_basename = "<MODULE_NAME>docs"
 
 
 # -- Options for LaTeX output ---------------------------------------------
+
+latex_engine = "xelatex"
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 from setuptools import (
     find_packages,
     setup,


### PR DESCRIPTION
### What was wrong?

Docs for `eth-utils` and `eth-account` use unicode characters that weren't supported by `pdflatex`, the default latex engine. To avoid any similar problems, we can switch to using `xelatex`.

Noticed a couple unnecessary `# -*- coding: utf-8 -*-` lines, so removed them too. 

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/ethereum-python-project-template/assets/5199899/8e76183f-366c-45f4-b226-d7782c6c3e34)
