### PR TITLE
Store Docs Artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,8 @@ docs: &docs
     - run:
         name: run tox
         command: python -m tox run -r
+    - store_artifacts:
+          path: /home/circleci/repo/docs/_build
     - save_cache:
         paths:
           - .tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ combine_as_imports = true
 extra_standard_library = "pytest"
 force_grid_wrap = 1
 force_sort_within_sections = true
+force_to_top = "pytest"
 honor_noqa = true
 known_first_party = "<MODULE_NAME>"
 known_third_party = "hypothesis"


### PR DESCRIPTION
### What was wrong?

CI Builds aren't keeping the artifacts they generate. It's nice to be able to verify what the true output will be.
The job now uses the artifact path to save the output.

Noticed thrash while working on a PR with the pytest import order. Fixed by forcing it to the top.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

<img width="559" alt="Screen Shot 2024-05-02 at 4 17 13 PM" src="https://github.com/ethereum/ethereum-python-project-template/assets/435903/ba090e22-f7a9-4d4a-be89-c7544c749e26">
