### PR TITLE
fix code blocks and version parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ package-test: clean
 
 notes: check-bump
 	# Let UPCOMING_VERSION be the version that is used for the current bump
-	$(eval UPCOMING_VERSION=$(shell bump-my-version show --increment $(bump) new_version))
+	$(eval UPCOMING_VERSION=$(shell bump-my-version bump --dry-run $(bump) -v | awk -F"'" '/New version will be / {print $$2}'))
 	# Now generate the release notes to have them included in the release commit
 	towncrier build --yes --version $(UPCOMING_VERSION)
 	# Before we bump the version, make sure that the towncrier-generated docs will build

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -12,12 +12,14 @@ To get started, fork the repository to your own github account, then clone it to
 development machine:
 
 .. code:: sh
+
     git clone git@github.com:your-github-username/<REPO_NAME>.git
 
 Next, install the development dependencies. We recommend using a virtual environment,
 such as `virtualenv <https://virtualenv.pypa.io/en/stable/>`_.
 
 .. code:: sh
+
     cd <REPO_NAME>
     virtualenv -p python venv
     . venv/bin/activate
@@ -32,6 +34,7 @@ A great way to explore the code base is to run the tests.
 We can run all tests with:
 
 .. code:: sh
+
     pytest tests
 
 Code Style
@@ -42,6 +45,7 @@ the library. This tool runs automatically with every commit, but you can also ru
 manually with:
 
 .. code:: sh
+
     make lint
 
 If you need to make a commit that skips the ``pre-commit`` checks, you can do so with
@@ -91,6 +95,7 @@ Final test before each release
 Before releasing a new version, build and test the package that will be released:
 
 .. code:: sh
+
     git checkout main && git pull
     make package-test
 
@@ -100,6 +105,7 @@ the instructions to activate the venv and test whatever you think is important.
 You can also preview the release notes:
 
 .. code:: sh
+
     towncrier --draft
 
 Build the release notes
@@ -110,6 +116,7 @@ the version to bump (see below), which changes how the version number will show 
 release notes.
 
 .. code:: sh
+
     make notes bump=$$VERSION_PART_TO_BUMP$$
 
 If there are any errors, be sure to re-run make notes until it works.
@@ -120,6 +127,7 @@ Push the release to github & pypi
 After confirming that the release package looks okay, release a new version:
 
 .. code:: sh
+
     make release bump=$$VERSION_PART_TO_BUMP$$
 
 This command will:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require = {
         "sphinx>=6.0.0",
         "sphinx-autobuild>=2021.3.14",
         "sphinx_rtd_theme>=1.0.0",
-        "towncrier>=21,<22",
+        "towncrier>=24,<25",
     ],
     "test": [
         "pytest>=7.0.0",


### PR DESCRIPTION
### What was wrong?

 - `code` blocks in `contributing.rst` were missing a newline that made the block not render.
 - Use of `bump-my-version` broke existing parsing of `make notes` for beta releases.
 - `towncrier` has started raising `pkg_resources`-related errors.

### How was it fixed?

 - Add newlines
 - Update version parsing line in `make notes`. Test PR is in hexbytes - https://github.com/ethereum/hexbytes/pull/48
 - Bump `towncrier` to `>=24,<25`. Test PR is in hexbytes - https://github.com/ethereum/hexbytes/pull/49

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/b33fa7dc-9940-451e-a993-ad8187408797)
