### PR TITLE
drop py38, add py13, add 2024 to license

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,16 +119,10 @@ jobs:
   docs:
     <<: *docs
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.10
         environment:
           TOXENV: docs
 
-  py38-core:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-        environment:
-          TOXENV: py38-core
   py39-core:
     <<: *common
     docker:
@@ -153,13 +147,13 @@ jobs:
       - image: cimg/python:3.12
         environment:
           TOXENV: py312-core
-
-  py38-lint:
+  py313-core:
     <<: *common
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.13
         environment:
-          TOXENV: py38-lint
+          TOXENV: py313-core
+
   py39-lint:
     <<: *common
     docker:
@@ -184,13 +178,13 @@ jobs:
       - image: cimg/python:3.12
         environment:
           TOXENV: py312-lint
-
-  py38-wheel:
+  py313-lint:
     <<: *common
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.13
         environment:
-          TOXENV: py38-wheel
+          TOXENV: py313-lint
+
   py39-wheel:
     <<: *common
     docker:
@@ -215,6 +209,12 @@ jobs:
       - image: cimg/python:3.12
         environment:
           TOXENV: py312-wheel
+  py313-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.13
+        environment:
+          TOXENV: py313-wheel
 
   py311-windows-wheel:
     <<: *windows-wheel-setup
@@ -242,25 +242,39 @@ jobs:
       - <<: *run-tox-step
       - <<: *save-cache-step
 
+  py313-windows-wheel:
+    <<: *windows-wheel-setup
+    steps:
+      - checkout
+      - <<: *restore-cache-step
+      - <<: *install-pyenv-step
+      - run:
+          name: set minor version
+          command: echo "export MINOR_VERSION='3.13'" >> $BASH_ENV
+      - <<: *install-latest-python-step
+      - <<: *run-tox-step
+      - <<: *save-cache-step
+
 define: &all_jobs
   - docs
-  - py38-core
   - py39-core
   - py310-core
   - py311-core
   - py312-core
-  - py38-lint
+  - py313-core
   - py39-lint
   - py310-lint
   - py311-lint
   - py312-lint
-  - py38-wheel
+  - py313-lint
   - py39-wheel
   - py310-wheel
   - py311-wheel
   - py312-wheel
+  - py313-wheel
   - py311-windows-wheel
   - py312-windows-wheel
+  - py313-windows-wheel
 
 workflows:
   version: 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v3.15.0
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py39-plus]
 -   repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,11 +43,14 @@ repos:
     -   id: mdformat
         additional_dependencies:
         -   mdformat-gfm
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+-   repo: local
     hooks:
-    -   id: mypy
-        exclude: tests/
+    -   id: mypy-local
+        name: run mypy with all dev dependencies present
+        entry: python -m mypy -p <MODULE_NAME>
+        language: system
+        always_run: true
+        pass_filenames: false
 -   repo: https://github.com/PrincetonUniversity/blocklint
     rev: v0.2.5
     hooks:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
   configuration: docs/conf.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2024 The Ethereum Foundation
+Copyright (c) 2019-2025 The Ethereum Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019-2023 The Ethereum Foundation
+Copyright (c) 2019-2024 The Ethereum Foundation
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
     install_requires=[
         "eth-utils>=2",
     ],
-    python_requires=">=3.8, <4",
+    python_requires=">=3.9, <4",
     extras_require=extras_require,
     py_modules=["<MODULE_NAME>"],
     license="MIT",
@@ -63,10 +63,10 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ extras_require = {
         "build>=0.9.0",
         "bump_my_version>=0.19.0",
         "ipython",
+        "mypy==1.10.0",
         "pre-commit>=3.4.0",
         "tox>=4.0.0",
         "twine",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{38,39,310,311,312}-core
-    py{38,39,310,311,312}-lint
-    py{38,39,310,311,312}-wheel
+    py{39,310,311,312,313}-core
+    py{39,310,311,312,313}-lint
+    py{39,310,311,312,313}-wheel
     windows-wheel
     docs
 
@@ -23,23 +23,23 @@ commands=
 basepython=
     docs: python
     windows-wheel: python
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12
+    py313: python3.13
 extras=
     test
     docs
 allowlist_externals=make,pre-commit
 
-[testenv:py{38,39,310,311,312}-lint]
+[testenv:py{39,310,311,313}-lint]
 deps=pre-commit
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure
 
-[testenv:py{38,39,310,311,312}-wheel]
+[testenv:py{39,310,311,312,313}-wheel]
 deps=
     wheel
     build[virtualenv]

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ extras=
     docs
 allowlist_externals=make,pre-commit
 
-[testenv:py{39,310,311,313}-lint]
+[testenv:py{39,310,311,312,313}-lint]
 deps=pre-commit
 commands=
     pre-commit install


### PR DESCRIPTION
### What was wrong?

py38 is out, py313 is in!

### How was it fixed?

Updated supported python versions. Bumped license date up to 2024.

Bumped docs build version to py310 to reduce urgency when py39 is dropped next year.

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/06a3eb64-de4b-4bef-873d-5f714272828a)
