### PR TITLE
Put python3.8 support back in:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,6 +123,12 @@ jobs:
         environment:
           TOXENV: docs
 
+  py38-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.8
+        environment:
+          TOXENV: py38-core
   py39-core:
     <<: *common
     docker:
@@ -154,6 +160,12 @@ jobs:
         environment:
           TOXENV: py313-core
 
+  py38-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.8
+        environment:
+          TOXENV: py38-lint
   py39-lint:
     <<: *common
     docker:
@@ -185,6 +197,12 @@ jobs:
         environment:
           TOXENV: py313-lint
 
+  py38-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.8
+        environment:
+          TOXENV: py38-wheel
   py39-wheel:
     <<: *common
     docker:
@@ -257,16 +275,19 @@ jobs:
 
 define: &all_jobs
   - docs
+  - py38-core
   - py39-core
   - py310-core
   - py311-core
   - py312-core
   - py313-core
+  - py38-lint
   - py39-lint
   - py310-lint
   - py311-lint
   - py312-lint
   - py313-lint
+  - py38-wheel
   - py39-wheel
   - py310-wheel
   - py311-wheel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v3.15.0
     hooks:
     -   id: pyupgrade
-        args: [--py39-plus]
+        args: [--py38-plus]
 -   repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     install_requires=[
         "eth-utils>=2",
     ],
-    python_requires=">=3.9, <4",
+    python_requires=">=3.8, <4",
     extras_require=extras_require,
     py_modules=["<MODULE_NAME>"],
     license="MIT",
@@ -64,6 +64,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{39,310,311,312,313}-core
-    py{39,310,311,312,313}-lint
-    py{39,310,311,312,313}-wheel
+    py{38,39,310,311,312,313}-core
+    py{38,39,310,311,312,313}-lint
+    py{38,39,310,311,312,313}-wheel
     windows-wheel
     docs
 
@@ -23,6 +23,7 @@ commands=
 basepython=
     docs: python
     windows-wheel: python
+    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
@@ -33,13 +34,13 @@ extras=
     docs
 allowlist_externals=make,pre-commit
 
-[testenv:py{39,310,311,312,313}-lint]
+[testenv:py{38,39,310,311,312,313}-lint]
 deps=pre-commit
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure
 
-[testenv:py{39,310,311,312,313}-wheel]
+[testenv:py{38,39,310,311,312,313}-wheel]
 deps=
     wheel
     build[virtualenv]


### PR DESCRIPTION
### What was wrong?

- We should create a breaking changes branch to be merged only when we are ready to start the next major version release cycle for all our maintained libraries.

### How was it fixed?

- Put support for Python 3.8 back into the template so it can still be applied to libraries before the breaking changes are introduced.

### Todo:

- [x] Clean up commit history

#### Cute Animal Picture

:o)
