### PR TITLE
lower pin on wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
         "pre-commit>=3.4.0",
         "tox>=4.0.0",
         "twine",
-        "wheel",
+        "wheel>=0.38.1",
     ],
     "docs": [
         "sphinx>=6.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands=
 
 [testenv:py{38,39,310,311,312,313}-wheel]
 deps=
-    wheel
+    wheel>=0.38.1
     build[virtualenv]
 allowlist_externals=
     /bin/rm
@@ -57,7 +57,7 @@ skip_install=true
 
 [testenv:windows-wheel]
 deps=
-    wheel
+    wheel>=0.38.1
     build[virtualenv]
 allowlist_externals=
     bash.exe


### PR DESCRIPTION
### What was wrong?

- We got this notice on `pyrlp`: https://github.com/ethereum/pyrlp/security/dependabot/2
- Better to be safe and lower pin ``wheel``.

### How was it fixed?

- `wheel>=0.38.1`

### Todo:

- [x] Clean up commit history

#### Cute Animal Picture

🐠 
