### PR TITLE
Drop python 3.8 and 3.9 support, add 3.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,18 +123,6 @@ jobs:
         environment:
           TOXENV: docs
 
-  py38-core:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-        environment:
-          TOXENV: py38-core
-  py39-core:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-        environment:
-          TOXENV: py39-core
   py310-core:
     <<: *common
     docker:
@@ -159,19 +147,13 @@ jobs:
       - image: cimg/python:3.13
         environment:
           TOXENV: py313-core
+  py314-core:
+    <<: *common
+    docker:
+      - image: cimg/python:3.14
+        environment:
+          TOXENV: py314-core
 
-  py38-lint:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-        environment:
-          TOXENV: py38-lint
-  py39-lint:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-        environment:
-          TOXENV: py39-lint
   py310-lint:
     <<: *common
     docker:
@@ -196,19 +178,13 @@ jobs:
       - image: cimg/python:3.13
         environment:
           TOXENV: py313-lint
+  py314-lint:
+    <<: *common
+    docker:
+      - image: cimg/python:3.14
+        environment:
+          TOXENV: py314-lint
 
-  py38-wheel:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-        environment:
-          TOXENV: py38-wheel
-  py39-wheel:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-        environment:
-          TOXENV: py39-wheel
   py310-wheel:
     <<: *common
     docker:
@@ -233,6 +209,12 @@ jobs:
       - image: cimg/python:3.13
         environment:
           TOXENV: py313-wheel
+  py314-wheel:
+    <<: *common
+    docker:
+      - image: cimg/python:3.14
+        environment:
+          TOXENV: py314-wheel
 
   py311-windows-wheel:
     <<: *windows-wheel-setup
@@ -246,7 +228,6 @@ jobs:
       - <<: *install-latest-python-step
       - <<: *run-tox-step
       - <<: *save-cache-step
-
   py312-windows-wheel:
     <<: *windows-wheel-setup
     steps:
@@ -259,7 +240,6 @@ jobs:
       - <<: *install-latest-python-step
       - <<: *run-tox-step
       - <<: *save-cache-step
-
   py313-windows-wheel:
     <<: *windows-wheel-setup
     steps:
@@ -272,30 +252,40 @@ jobs:
       - <<: *install-latest-python-step
       - <<: *run-tox-step
       - <<: *save-cache-step
+  py314-windows-wheel:
+    <<: *windows-wheel-setup
+    steps:
+      - checkout
+      - <<: *restore-cache-step
+      - <<: *install-pyenv-step
+      - run:
+          name: set minor version
+          command: echo "export MINOR_VERSION='3.14'" >> $BASH_ENV
+      - <<: *install-latest-python-step
+      - <<: *run-tox-step
+      - <<: *save-cache-step
 
 define: &all_jobs
   - docs
-  - py38-core
-  - py39-core
   - py310-core
   - py311-core
   - py312-core
   - py313-core
-  - py38-lint
-  - py39-lint
+  - py314-core
   - py310-lint
   - py311-lint
   - py312-lint
   - py313-lint
-  - py38-wheel
-  - py39-wheel
+  - py314-lint
   - py310-wheel
   - py311-wheel
   - py312-wheel
   - py313-wheel
+  - py314-wheel
   - py311-windows-wheel
   - py312-windows-wheel
   - py313-windows-wheel
+  - py314-windows-wheel
 
 workflows:
   version: 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v3.15.0
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--py310-plus]
 -   repo: https://github.com/psf/black
     rev: 23.9.1
     hooks:

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ setup(
     python_requires=">=3.10, <4",
     extras_require=extras_require,
     py_modules=["<MODULE_NAME>"],
-    license="MIT",
     zip_safe=False,
     keywords="ethereum",
     packages=find_packages(exclude=["scripts", "scripts.*", "tests", "tests.*"]),

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     install_requires=[
         "eth-utils>=2",
     ],
-    python_requires=">=3.8, <4",
+    python_requires=">=3.10, <4",
     extras_require=extras_require,
     py_modules=["<MODULE_NAME>"],
     license="MIT",
@@ -64,11 +64,10 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_require = {
         "build>=0.9.0",
         "bump_my_version>=0.19.0",
         "ipython",
-        "mypy==1.10.0",
+        "mypy==1.18.2",
         "pre-commit>=3.4.0",
         "tox>=4.0.0",
         "twine",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist=
-    py{38,39,310,311,312,313}-core
-    py{38,39,310,311,312,313}-lint
-    py{38,39,310,311,312,313}-wheel
+    py{310,311,312,313,314}-core
+    py{310,311,312,313,314}-lint
+    py{310,311,312,313,314}-wheel
     windows-wheel
     docs
 
@@ -23,24 +23,23 @@ commands=
 basepython=
     docs: python
     windows-wheel: python
-    py38: python3.8
-    py39: python3.9
     py310: python3.10
     py311: python3.11
     py312: python3.12
     py313: python3.13
+    py314: python3.14
 extras=
     test
     docs
 allowlist_externals=make,pre-commit
 
-[testenv:py{38,39,310,311,312,313}-lint]
+[testenv:py{310,311,312,313,314}-lint]
 deps=pre-commit
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure
 
-[testenv:py{38,39,310,311,312,313}-wheel]
+[testenv:py{310,311,312,313,314}-wheel]
 deps=
     wheel>=0.38.1
     build[virtualenv]


### PR DESCRIPTION
### What was wrong?
Adds Python 3.14, drops Python 3.8 (if needed) and 3.9. Updates mypy 

### How was it fixed?
Adds to CI, updates mypy in setup. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>) No internet :(
