### PR TITLE
Update pyupgrade version requirement in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py310-plus]


### PR DESCRIPTION
### What was wrong?
The Pyupgrade step started failing in CI in the pre-commit hook. For example: https://app.circleci.com/jobs/github/ethereum/hexbytes/8425. Updating Pyupgrade to 3.21.2 fixes it. 

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/<REPO_NAME>/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://static.independent.co.uk/s3fs-public/thumbnails/image/2016/09/05/10/cubs9.jpg)
